### PR TITLE
Remove test data exclusion from .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ tags
 *.egg-info
 
 # Unittest and coverage
-tests/data/*
+tests/data/NREL*
 htmlcov/*
 .coverage
 .tox
@@ -50,7 +50,6 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
-{}
 
 # Django
 /*.sqlite3

--- a/tests/data/scienta2D.txt
+++ b/tests/data/scienta2D.txt
@@ -1,0 +1,41 @@
+[Info]
+Number of Regions=0002
+Version=1.3.1
+
+[Region 1]
+Region Name=foo
+Dimension 1 name=Binding Energy [eV]
+Dimension 1 size=2
+Dimension 1 scale=624 625
+Dimension 2 name=Y-Scale [mm]
+Dimension 2 size=2
+Dimension 2 scale=1.234 5.678
+
+[Info 1]
+Region Name=foo
+Energy Step=1
+[Run Mode Information 1]
+
+
+[Data 1]
+ 6.24e02 1.00e00 2.00e00
+ 6.25e02 3.00e00 4.00e00
+
+[Region 2]
+Region Name=bar
+Dimension 1 name=Binding Energy [eV]
+Dimension 1 size=2
+Dimension 1 scale=148 148.5
+Dimension 2 name=Y-Scale [mm]
+Dimension 2 size=2
+Dimension 2 scale=9.012 3.456
+
+[Info 2]
+Region Name=bar
+Energy Step=0.5
+[Run Mode Information 2]
+
+
+[Data 2]
+  1.480e02 5.00e00 6.00e00
+  1.485e02 7.00e00 8.00e00

--- a/tests/data/scienta3D.txt
+++ b/tests/data/scienta3D.txt
@@ -1,0 +1,35 @@
+[Info]
+Number of Regions=0001
+Version=0.0.1
+
+[Region 1]
+Region Name=foo
+Dimension 1 name=Binding Energy [eV]
+Dimension 1 size=4
+Dimension 1 scale=624 625 626 627
+Dimension 2 name=Y-Scale [mm]
+Dimension 2 size=3
+Dimension 2 scale=1.234 5.678 9.012
+Dimension 3 name=Seq. Iteration[a.u.]
+Dimension 3 size=2
+Dimension 3 scale=1 2
+
+[Info 1]
+Region Name=foo
+Energy Step=1
+[Run Mode Information 1]
+Name=Add Dimension
+
+
+[Data 1:1]
+ 6.24e02 1.00e00 2.00e00 3.00e00
+ 6.25e02 4.00e00 5.00e00 6.00e00
+ 6.26e02 7.00e00 8.00e00 9.00e00
+ 6.27e02 1.00e01 1.10e01 1.20e01
+
+
+[Data 1:2]
+ 6.24e02 1.30e01 1.40e01 1.50e01
+ 6.25e02 1.60e01 1.70e01 1.80e01
+ 6.26e02 1.90e01 2.00e01 2.10e01
+ 6.27e02 2.20e01 2.30e01 2.40e01


### PR DESCRIPTION
The prototype to minespex used data from NREL, but this data is quite
large (5-10 GB). During development, the tests/data folder was excluded
from the repo to prevent the repo from becoming too large.

This had the inevitable effect of excluding the simplified data created
to test the Spectra class and the Scienta read function. This purpose
of this commit is simple--include the smaller test data into the repo.